### PR TITLE
Fix a little react warning, pass key directly instead of spread

### DIFF
--- a/app/(studio)/generate/page.tsx
+++ b/app/(studio)/generate/page.tsx
@@ -262,7 +262,6 @@ export default function Page() {
 
   const imageFormProps = {
     ...commonFormProps,
-    key: 'image-form',
     generationType: 'Image' as const,
     onImageGeneration: handleImageGeneration,
     randomPrompts: ImageRandomPrompts,
@@ -273,7 +272,6 @@ export default function Page() {
 
   const videoFormProps = {
     ...commonFormProps,
-    key: 'video-form',
     generationType: 'Video' as const,
     onVideoPollingStart: handleVideoPollingStart,
     randomPrompts: VideoRandomPrompts,
@@ -298,8 +296,8 @@ export default function Page() {
             weight={500}
           />
 
-          {isImageMode && <GenerateForm {...imageFormProps} />}
-          {isVideoEnabled && !isImageMode && <GenerateForm {...videoFormProps} />}
+          {isImageMode && <GenerateForm key="image-form" {...imageFormProps} />}
+          {isVideoEnabled && !isImageMode && <GenerateForm key="video-form" {...videoFormProps} />}
         </Grid>
         <Grid size={0.9} flex={1} sx={{ pt: 14, maxWidth: 850, minWidth: 400 }}>
           {isImageMode ? (


### PR DESCRIPTION
A tiny PR, just to fix a react warning saying to pass key directly to JSX without using spread :

<img width="1671" height="177" alt="image" src="https://github.com/user-attachments/assets/832346a5-97e2-48cd-be41-6447bf3ee527" />
